### PR TITLE
Add community calendar

### DIFF
--- a/events.md
+++ b/events.md
@@ -14,6 +14,10 @@ ads: false
 ---
 
 <iframe src="https://www.google.com/calendar/embed?src=computer.tech.society.nl%40gmail.com&ctz=America/St_Johns" style="border: 0" width="700" height="425" frameborder="0" scrolling="no"></iframe>
+
+<br>
+
+<iframe src="https://calendar.google.com/calendar/embed?src=lg91l2ngk9ee09qi1k12dmaneg%40group.calendar.google.com&ctz=America/St_Johns" style="border: 0" width="700" height="425" frameborder="0" scrolling="no"></iframe>
 <!--
 ##Events
 

--- a/events.md
+++ b/events.md
@@ -3,7 +3,7 @@ layout: article
 title: "Calendar"
 permalink: /events/
 date: 2015-07-15
-modified: 2015-08-21
+modified: 2016-02-11
 excerpt: "Check out our upcoming calendar of events."
 image:
     feature:
@@ -12,32 +12,40 @@ image:
 share: false
 ads: false
 ---
+<style>
+    @import url('http://fonts.googleapis.com/css?family=Open+Sans:400,600,700');
+   
+    *, *:before, *:after {margin: 0; padding: 0; box-sizing: border-box;}
+    .tabs {margin: 0 auto; min-width: 320px; max-width: 800px;}
+    .content {color: #000;}
+    .content > div {display: none; padding: 20px 25px 5px;}
 
-<iframe src="https://www.google.com/calendar/embed?src=computer.tech.society.nl%40gmail.com&ctz=America/St_Johns" style="border: 0" width="700" height="425" frameborder="0" scrolling="no"></iframe>
+    .tabs input {display: none;}
+    .tabs label {display: inline-block; padding: 15px 25px; font-weight: 600; text-align: center;}
+    .tabs label:hover {color: #000; cursor: pointer;}
+    .tabs input:checked + label {background: #f0f0f0; color: #000;}
 
-<br>
+    #tab1:checked ~ .content #content1,
+    #tab2:checked ~ .content #content2 {
+        display: block;
+    }
+ 
+    @media screen and (max-width: 400px) { label {padding: 15px 10px;} }
+</style>
 
-<iframe src="https://calendar.google.com/calendar/embed?src=lg91l2ngk9ee09qi1k12dmaneg%40group.calendar.google.com&ctz=America/St_Johns" style="border: 0" width="700" height="425" frameborder="0" scrolling="no"></iframe>
-<!--
-##Events
+<div class="tabs">
+    <input id="tab1" type="radio" name="tabs" checked>
+    <label for="tab1">CTS-NL Events Calendar</label>
 
-###CTS-NL Events
-- [Talk Series #1](http://eepurl.com/btosZb) - July 23rd at 7pm  
-    **Speaker:** Whymarrh Whitby  
-    **Topic:** "A practical introduction to (unit) testing your software"  
-    **Location:** Room EN-2043 of the Engineering building at MUN
-- Meetup #8 - Date TBA
+    <input id="tab2" type="radio" name="tabs">
+    <label for="tab2">Community Calendar</label>
 
-###Other Events in the Community
-- ProtoShed Weekly Meeting - July 21st at 5:30pm  
-    **Location:** Victoria Park Pool House, Angel Place, St. John's
-- ProtoShed Weekly Meeting - Julty 25th at 1pm  
-    **Location:** Common Ground Coworking, 30 Harvey Road #2, St. John's
-- ProtoShed Weekly Meeting - July 28th at 5:30pm  
-    **Location:** Victoria Park Pool House, Angel Place, St. John's
-- CodeNL Talk #7 and Q & A - July 28th at 7pm  
-    **Speaker:** Mark Simms  
-    **Topic:** (Mostly) Surviving Success  
-    **Location:** Room EN-2043 of the Engineering building at MUN  
-    
-Work in progress-->
+    <div class="content">
+        <div id="content1">
+            <iframe src="https://www.google.com/calendar/embed?src=computer.tech.society.nl%40gmail.com&amp;showTitle=0&amp;bgcolor=%23fcfcfd&amp;ctz=America/St_Johns" style="border: 0" width="700" height="425" frameborder="0" scrolling="no"></iframe>
+        </div>
+        <div id="content2">
+            <iframe src="https://calendar.google.com/calendar/embed?src=lg91l2ngk9ee09qi1k12dmaneg%40group.calendar.google.com&amp;showTitle=0&amp;bgcolor=%23fcfcfd&amp;ctz=America/St_Johns" style="border: 0" width="700" height="425" frameborder="0" scrolling="no"></iframe>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
- Add community calendar to the Calendar & Events page
- Add tabs to the page for switching between calendars
- Remove old commented code from bottom of file
- Modify google calendar iframe code to match the background and remove titles as new tabs act as

This relates to #13 
