### PR TITLE
Add community calendar to the Calendar & Events page

### DIFF
--- a/_layouts/article-full.html
+++ b/_layouts/article-full.html
@@ -1,0 +1,32 @@
+---
+layout: default
+---
+
+<div id="main" role="main">
+	<article class="wrap" itemscope itemtype="http://schema.org/Article">
+		{% if page.image.feature %}
+		<div class="page-feature">
+			<div class="page-image">
+				<img src="{{ site.url }}/images/{{ page.image.feature }}" class="page-feature-image" alt="{{ page.title }}" itemprop="image">
+				{% if page.image.credit %}{% include image-credit.html %}{% endif %}
+			</div><!-- /.page-image -->
+		</div><!-- /.page-feature -->
+		{% endif %}
+		{% include breadcrumbs.html %}
+		<div class="page-title">
+			<h1>{{ page.title }}</h1>
+		</div>
+		<div id="content" class="page-content" itemprop="articleBody">
+			{{ content }}
+			<hr />
+			<footer class="page-footer">
+				{% if page.categories %}{% include page-author.html %}{% endif %}
+				{% if page.share != false %}{% include share-this.html %}{% endif %}
+				{% include page-meta.html %}
+			</footer><!-- /.footer -->
+			<aside>
+				{% if page.comments == true %}{% include comments.html %}{% endif %}
+			</aside>
+		</div><!-- /.content -->
+	</article><!-- ./wrap -->
+</div><!-- /#main -->

--- a/events.md
+++ b/events.md
@@ -1,9 +1,9 @@
 ---
-layout: article
+layout: article-full
 title: "Calendar"
 permalink: /events/
 date: 2015-07-15
-modified: 2015-08-21
+modified: 2016-03-05
 excerpt: "Check out our upcoming calendar of events."
 image:
     feature:
@@ -12,28 +12,40 @@ image:
 share: false
 ads: false
 ---
+<style>
+    @import url('http://fonts.googleapis.com/css?family=Open+Sans:400,600,700');
+   
+    *, *:before, *:after {margin: 0; padding: 0; box-sizing: border-box;}
+    .tabs {margin: 0 auto; min-width: 320px;}
+    .content {color: #000;}
+    .content > div {display: none; padding: 20px 25px 5px;}
 
-<iframe src="https://www.google.com/calendar/embed?src=computer.tech.society.nl%40gmail.com&ctz=America/St_Johns" style="border: 0" width="700" height="425" frameborder="0" scrolling="no"></iframe>
-<!--
-##Events
+    .tabs input {display: none;}
+    .tabs label {display: inline-block; padding: 15px 25px; font-weight: 600; text-align: center;}
+    .tabs label:hover {color: #000; cursor: pointer;}
+    .tabs input:checked + label {background: #f0f0f0; color: #000;}
 
-###CTS-NL Events
-- [Talk Series #1](http://eepurl.com/btosZb) - July 23rd at 7pm  
-    **Speaker:** Whymarrh Whitby  
-    **Topic:** "A practical introduction to (unit) testing your software"  
-    **Location:** Room EN-2043 of the Engineering building at MUN
-- Meetup #8 - Date TBA
+    #tab1:checked ~ .content #content1,
+    #tab2:checked ~ .content #content2 {
+        display: block;
+    }
+ 
+    @media screen and (max-width: 400px) { label {padding: 15px 10px;} }
+</style>
 
-###Other Events in the Community
-- ProtoShed Weekly Meeting - July 21st at 5:30pm  
-    **Location:** Victoria Park Pool House, Angel Place, St. John's
-- ProtoShed Weekly Meeting - Julty 25th at 1pm  
-    **Location:** Common Ground Coworking, 30 Harvey Road #2, St. John's
-- ProtoShed Weekly Meeting - July 28th at 5:30pm  
-    **Location:** Victoria Park Pool House, Angel Place, St. John's
-- CodeNL Talk #7 and Q & A - July 28th at 7pm  
-    **Speaker:** Mark Simms  
-    **Topic:** (Mostly) Surviving Success  
-    **Location:** Room EN-2043 of the Engineering building at MUN  
-    
-Work in progress-->
+<div class="tabs">
+    <input id="tab1" type="radio" name="tabs" checked>
+    <label for="tab1">CTS-NL Events Calendar</label>
+
+    <input id="tab2" type="radio" name="tabs">
+    <label for="tab2">Community Calendar</label>
+
+    <div class="content">
+        <div id="content1">
+            <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23fcfcfd&amp;src=computer.tech.society.nl%40gmail.com&amp;color=%238C500B&amp;ctz=America%2FSt_Johns" style="border-width:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+        </div>
+        <div id="content2">
+            <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23fcfcfd&amp;src=lg91l2ngk9ee09qi1k12dmaneg%40group.calendar.google.com&amp;color=%238C500B&amp;ctz=America%2FSt_Johns" style="border-width:0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Add tabs to the page for switching between calendars

Remove old commented code from bottom of file
Modify google calendar iframe code to match the background and remove titles as new tabs act as titles

Update bgcolor of embeded calendars to match page
