### PR TITLE
Fix about page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: We are a new group that is trying to create a community for anyone 
 logo: logo.png # 120x120 px default image used for Twitter summary card
 teaser: teaser.jpg # 400x250 px default teaser image used in image archive grid
 locale:
-url: 
+url:
 
 # Jekyll configuration
 
@@ -16,7 +16,7 @@ sass:
 permalink: /:categories/:title/
 kramdown:
   toc_levels: 1..2
-highlighter: pygments
+highlighter: rouge
 gems:
   - jekyll-sitemap
 
@@ -27,9 +27,9 @@ owner:
   email: computer.tech.society.nl@gmail.com
   twitter: CTS_NL
   google:
-    ad-client: 
-    ad-slot: 
-  bio: 
+    ad-client:
+    ad-slot:
+  bio:
   avatar: bio-photo.png # 160x160 px image for author byline
 disqus-shortname:
 

--- a/about.md
+++ b/about.md
@@ -3,7 +3,7 @@ layout: article
 title: "About Us"
 permalink: /about/
 date: 2015-07-15
-modified: 2015-08-21
+modified: 2016-03-06
 excerpt: "Learn about who we are and what we do."
 image:
     feature:
@@ -15,18 +15,18 @@ ads: false
 <!--
 This page is still a work in progress.
 
-##History
+## History
 
-##Goals
+## Goals
 We are a new group that is trying to create a community for anyone in Newfoundland and Labrador that works or has interest in computers and technology.
 
-##Mission Statement
+## Mission Statement
 -->
 
-##Who We Are & What We Do
-We are a new group that is trying to create a community for anyone in Newfoundland and Labrador that works or has interest in computers and technology. We like to have monthly meetups to just get together over a coffee/beer to chat about various topics, such as current tech news, what we are using/dealing with in our jobs, or even our current side projects. These meetups alternate locations between, Dooly's and The Rocket Bakery. We have recently started having monthly tech talks from our members and other sources. These talks lean towards a more technical side than the CodeNL talks. We also take part in local outreach programs, such as the CodeNL events, to help promote programming education in Newfoundland and Labrador. Below is a list of our executive who all work together to organize these events.
+## Who We Are & What We Do
+We are a new group that is trying to create a community for anyone in Newfoundland and Labrador that works or has interest in computers and technology. We like to have monthly meetups to just get together over a coffee/beer to chat about various topics, such as current tech news, what we are using/dealing with in our jobs, or even our current side projects. These meetups have alternated locations between Dooly's, The Rocket Bakery, and more recently we have gone to Jumping Bean on Elizabeth Ave and West Side Charlies on Kenmount Road. We have recently started having semi monthly tech talks from our members and other sources. These talks lean towards a more technical side than the CodeNL talks. We also take part in local outreach programs, such as the CodeNL events, to help promote programming education in Newfoundland and Labrador. Below is a list of our executive who all work together to organize these events.
 
-##Executive Members
+## Executive Members
 - Tim Oram
 - Mark Stacey
 - Mike Burton

--- a/contact.md
+++ b/contact.md
@@ -3,7 +3,7 @@ layout: article
 title: "Contact Us"
 permalink: /contact/
 date: 2015-07-15
-modified: 2015-08-21
+modified: 2016-03-05
 excerpt: "How to get in contact with us."
 image:
     feature:


### PR DESCRIPTION
With GitHub's recent upgrade to Jekyll 3 I had to fix some markdown on the about page. So while I was at it I addressed the "grammatical" issue that was logged.
